### PR TITLE
 Updated xml for possible version-10 submission

### DIFF
--- a/draft-azimov-sidrops-aspa-verification.xml
+++ b/draft-azimov-sidrops-aspa-verification.xml
@@ -13,9 +13,12 @@
         <!ENTITY RFC5280 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5280.xml">
         <!ENTITY RFC3779 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3779.xml">
         <!ENTITY RFC9234 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.9234.xml">
-        <!ENTITY I-D.ietf-grow-route-leak-detection-mitigation SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-grow-route-leak-detection-mitigation.xml">
-        <!ENTITY I-D.ietf-sidrops-aspa-profile SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-sidrops-aspa-profile.xml">
-        <!ENTITY I-D.white-sobgp-architecture SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-white-sobgp-architecture-02.xml">
+
+<!ENTITY I-D.ietf-grow-route-leak-detection-mitigation SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-grow-route-leak-detection-mitigation.xml">
+
+<!ENTITY I-D.ietf-sidrops-aspa-profile SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-sidrops-aspa-profile.xml">
+
+<!ENTITY I-D.white-sobgp-architecture SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-white-sobgp-architecture-02.xml">
         <!ENTITY I-D.ietf-idr-deprecate-as-set-confed-set SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-idr-deprecate-as-set-confed-set.xml">
         ]>
 
@@ -28,7 +31,7 @@
 <?rfc compact="yes" ?>
 <?rfc subcompact="no" ?>
 
-<rfc category="std" docName="draft-ietf-sidrops-aspa-verification-09" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-sidrops-aspa-verification-10" ipr="trust200902">
   <front>
 
     <title abbrev="AS_PATH Verification">
@@ -517,4 +520,5 @@ The ASes on the boundary of an AS Confederation MUST register ASPAs using the Co
     </references>
   </back>
 </rfc>
+
 

--- a/draft-azimov-sidrops-aspa-verification.xml
+++ b/draft-azimov-sidrops-aspa-verification.xml
@@ -6,15 +6,17 @@
         <!ENTITY RFC4271 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4271.xml">
         <!ENTITY RFC8205 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.8205.xml">
         <!ENTITY RFC6483 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6483.xml">
+        <!ENTITY RFC6811 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6811.xml">
         <!ENTITY RFC7908 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.7908.xml">
+        <!ENTITY RFC6472 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6472.xml">
         <!ENTITY RFC6480 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6480.xml">
         <!ENTITY RFC5280 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5280.xml">
         <!ENTITY RFC3779 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3779.xml">
         <!ENTITY RFC9234 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.9234.xml">
-        <!ENTITY I-D.ietf-grow-route-leak-detection-mitigation SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-grow-route-leak-detection-mitigation-00.xml">
-        <!ENTITY I-D.ietf-sidrops-aspa-profile SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-sidrops-aspa-profile-00.xml">
+        <!ENTITY I-D.ietf-grow-route-leak-detection-mitigation SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-grow-route-leak-detection-mitigation.xml">
+        <!ENTITY I-D.ietf-sidrops-aspa-profile SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-ietf-sidrops-aspa-profile.xml">
         <!ENTITY I-D.white-sobgp-architecture SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-white-sobgp-architecture-02.xml">
-        <!ENTITY I-D.draft-kumari-deprecate-as-set-confed-set SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.draft-kumari-deprecate-as-set-confed-set-12.xml">
+        <!ENTITY I-D.ietf-idr-deprecate-as-set-confed-set SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.ietf-idr-deprecate-as-set-confed-set.xml">
         ]>
 
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -34,7 +36,7 @@
     </title>
 
     <author fullname="Alexander Azimov" initials="A" 
-            surname="Azimov (Ed.)">
+            surname="Azimov">
       <organization>Yandex</organization>
       <address>
         <email>a.e.azimov@gmail.com</email>
@@ -51,7 +53,7 @@
 
     <author fullname="Randy Bush" initials="R"
         surname="Bush">
-        <organization>Internet Initiative Japan &amp; Arrcus</organization>
+      <organization abbrev="IIJ &amp; Arrcus">Internet Initiative Japan &amp; Arrcus</organization>
         <address>
             <email>randy@psg.com</email>
         </address>
@@ -59,7 +61,7 @@
 
     <author fullname="Keyur Patel" initials="K"
             surname="Patel">
-      <organization>Arrcus, Inc.</organization>
+      <organization>Arrcus</organization>
       <address>
         <email>keyur@arrcus.com</email>
       </address>
@@ -77,6 +79,21 @@
         <email>job@fastly.com</email>
       </address>
     </author>
+
+	      <author fullname="Kotikalapudi Sriram" initials="K." surname="Sriram">
+      <organization abbrev="USA NIST">USA National Institute of Standards and Technology</organization>
+      <address>
+        <postal>
+          <street>100 Bureau Drive</street>
+          <city>Gaithersburg</city>
+          <region>MD</region>
+          <code>20899</code>
+          <country>United States of America</country>
+        </postal>
+        <email>ksriram@nist.gov</email>
+      </address>
+    </author>
+
 
     <date />
 
@@ -103,40 +120,40 @@
 
     <section title="Introduction" anchor="intro">
       <t>
-        The Border Gateway Protocol (BGP) was designed without mechanisms to validate BGP attributes.
-        Two consequences are BGP Hijacks and BGP Route Leaks <xref target="RFC7908" />.
+        The Border Gateway Protocol (BGP) was designed without mechanisms to validate the attributes in BGP UPDATEs.
+        Two of the consequences amongst several are BGP hijacks and BGP route leaks <xref target="RFC7908"/>.
         BGP extensions are able to partially solve these problems.
-        For example, ROA-based Origin Validation <xref target="RFC6483" /> can be used to detect and filter accidental mis-originations, and <xref target="RFC9234"/> or <xref target="I-D.ietf-grow-route-leak-detection-mitigation"/> can be used to detect accidental route leaks.
-        While these upgrades to BGP are quite useful, they still rely on transitive BGP attributes, i.e. AS_PATH, that can be manipulated by attackers.
+        For example, ROA-based route origin validation (ROV) <xref target="RFC6483" /> <xref target="RFC6811"/> can be used to detect and filter accidental mis-originations, and <xref target="RFC9234"/> or <xref target="I-D.ietf-grow-route-leak-detection-mitigation"/> can be used to detect and mitigate accidental route leaks.
+        While these upgrades to BGP are quite useful, they still rely on transitive BGP attributes, e.g., AS_PATH, that can be manipulated by attackers.
       </t>
       <t>
-        BGPsec <xref target="RFC8205" /> was designed to solve the problem of AS_PATH validation using a cryptographic signatures included in the UPDATE.
+        BGPsec <xref target="RFC8205" /> was designed to solve the problem of AS_PATH validation using cryptographic signatures included in the UPDATE.
         Unfortunately, the cryptographic validation of path signatures results in significant computational overhead for BGP routers.
         More importantly, while BGPsec offers protection against path or prefix modifications, it does not protect against route leaks.
       </t>
       <t>
         An alternative approach was introduced with soBGP <xref target="I-D.white-sobgp-architecture"/>.
         Instead of strong cryptographic AS_PATH validation, it created an AS_PATH security function based on a shared database of AS adjacencies.
-        While such an approach has reasonable computational cost, the two-side adjacencies don't provide a way to automate anomaly detection without high adoption rate - an attacker can easily create a one-way adjacency.
+        While such an approach has reasonable computational cost, the two-side adjacencies do not provide a way to automate anomaly detection without high adoption rate - an attacker can easily create a one-way adjacency.
         soBGP transported data about adjacencies in new additional BGP messages, which was recursively complex thus significantly increasing adoption complexity.
-        In addition, the general goal of verification of all AS_PATHs was not achievable given the indirect adjacencies at Internet exchange points.
+        In addition, the general goal of verification of all AS_PATHs was not achievable given the indirect adjacencies at Internet exchange (IX) points.
       </t>
       <t>
-        Instead of strictly checking AS_PATH correctness, this document focuses on solving real-world operational problems - automatic detection of route leaks and combined with ROA detection of malicious bgp hijacks.
-        To achieve this, new AS_PATH verification procedures are described to automatically detect invalid (malformed) AS_PATHs in announcements that are received from customers, peers, providers, Route Servers (RSes), and RS-clients.
-        These procedures use a shared signed database of customer-to-provider relationships using a new RPKI object - Autonomous System Provider Authorization (ASPA).
+        Instead of strictly checking the AS_PATH correctness, this document focuses on solving real-world operational problems - the automatic detection of route leaks and the detection of malicious (i.e., forged-origin) BGP hijacks. The latter is accomplished in conjunction with ROAs and ROV.
+        To achieve this, new AS_PATH verification procedures are described to automatically detect invalid (malformed) AS_PATHs in announcements that are received from customers, lateral peers (defined in <xref target="RFC7908"/>), transit providers, Route Servers (RSes), and RS-clients.
+        These procedures use a shared database of cryptographically signed customer-to-provider relationships using a new Resource Public Key Infrastructure (RPKI) object - Autonomous System Provider Authorization (ASPA).
         This technique provides benefits for participants even during early and incremental adoption.
       </t>
     </section>
 
     <section title="Anomaly Propagation" anchor="propagation">
       <t>
-        Both route leaks and hijacks have similar effects on ISP operations - they redirect traffic, resulting in denial of service (DoS), eavesdropping, increased latency and packet loss.
+        Both route leaks and hijacks have similar effects on ISP operations - they redirect traffic resulting in denial of service (DoS), eavesdropping, increased latency, and packet loss.
         But the level of risk depends significantly on the extent of propagation of the anomalies.
-        For example, a hijack that is propagated only to customers may cause bottlenecking within a particular ISP's customer cone, but if the anomaly is propagated through peers, upstreams, or reaches Tier-1 networks, thus distributing globally, the ill effects will likely be experienced across continents.
+        For example, a hijack that is propagated only to customers may cause bottlenecking within a particular ISP's customer cone, but if the anomaly propagates through lateral (i.e., non-transit)peers and transit providers, or reaches Tier-1 networks thus distributing globally, then the ill effects will likely be experienced across continents.
       </t>
       <t>
-        The ability to constrain propagation of BGP anomalies to upstreams and peers, without requiring support from the source of the anomaly (which is critical if source has malicious intent), should significantly improve the security of inter-domain routing and solve the majority of problems.
+        The ability to constrain propagation of BGP anomalies to transit providers and lateral peers - without requiring support from the source of the anomaly (which is critical if the source has malicious intent) - should significantly improve the security of inter-domain routing and solve a majority of problems.
       </t>
     </section>
 
@@ -149,247 +166,286 @@
       </t>
 
       <t>
-        ASPA is digitally signed object that bind, for a selected AFI, a Set of Provider AS numbers to a Customer AS number (in terms of BGP announcements not business), and are signed by the holder of the Customer AS.
-        An ASPA  attests that a Customer AS holder (CAS) has authorized Set of Provider ASes (SPAS) to propagate the Customer's IPv4/IPv6 announcements onward, e.g. to the Provider's upstream providers or peers.
+        ASPA is a digitally signed object that binds, for a selected AFI, a Set of Provider AS numbers to a Customer AS number (in terms of BGP announcements, not business relationship), and are signed by the holder of the Customer AS.
+        An ASPA attests that a Customer AS holder (CAS) has authorized a Set of Provider ASes (SPAS) to propagate the Customer's IPv4/IPv6 announcements onward, e.g., to the Provider's upstream providers or lateral peers.
         The ASPA record profile is described in <xref target="I-D.ietf-sidrops-aspa-profile"/>.
-        For a selected Customer AS SHOULD exist only single ASPA object at any time.
-        In this document we will use ASPA(AS1, AFI, [AS2, ...]) as notation to represent ASPA object for AS1 in the selected AFI.
+        In this document, the notation (AS1, AFI, [AS2,...]) is used to represent the ASPA object for AS1 in the selected AFI. In this example, AS2 and any other ASes listed in the square brackets represent the transit provider ASes. 
       </t>
     </section>
 
     <section title="Customer-Provider Verification Procedure" anchor="pair-validation">
       <t>
-        This section describes an abstract procedure that checks that a pair of ASNs (AS1, AS2) is included in the set of signed ASPAs.
-        The semantics of its use is defined in next section.
-        The procedure takes (AS1, AS2, AFI) as input parameters and returns one of three results: "Valid", "Invalid" and "Unknown".
+        This section describes a procedure for checking that an ordered pair of AS numbers (ASNs), e.g., (AS1, AS2), has the property that AS2 is an attested provider of AS1 per ASPA.  
+        This procedure is used in ASPA-based AS_PATH validation as described in <xref target="verif"/>.
+        The procedure takes (AS1, AS2, AFI) as input parameters and returns one of three possible results, which are "Valid", "Invalid", and "Unknown".
       </t>
       <t>
-        A relying party (RP) must have access to a local cache of the complete set of cryptographically valid ASPAs when performing customer-provider verification procedure.
+        A relying party (RP) must have access to a local cache of the complete set of cryptographically valid ASPAs when performing the customer-provider verification procedure.
       </t>
       <t>
-        The following algorithm describes the customer-provider verification procedure for selected AFI:
+        The following algorithm describes the customer-provider verification procedure for a selected AFI:
         <list style="numbers">
           <t>
-            Retrieve all cryptographically valid ASPAs in a selected AFI with a customer value of AS1.
-            The union of SPAS forms the set of "Candidate Providers."
+            Retrieve all cryptographically valid ASPAs with the selected AFI that have a customer value of AS1.
+            The union of SPAS from these ASPAs forms the set of Candidate Providers.
           </t>
           <t>
-            If the set of Candidate Providers is empty, then the procedure exits with an outcome of "Unknown."
+            If the set of Candidate Providers is empty, then the procedure exits with an outcome of "Unknown".
           </t>
           <t>
-            If AS2 is included in the Candidate Providers, then the procedure exits with an outcome of "Valid."
+            If AS2 is included in the set of Candidate Providers, then the procedure exits with an outcome of "Valid".
           </t>
           <t>
-            Otherwise, the procedure exits with an outcome of "Invalid."
+            Otherwise, the procedure exits with an outcome of "Invalid".
           </t>
         </list>
       </t>
       <t>
-        Since an AS1 may have different set of providers in different AFI, it should also have different SPAS in corresponding ASPAs.
-        In this case, the output of this procedure with input (AS1, AS2, AFI) may have different output for different AFI values.
+        Since an AS may have different sets of providers for different AFI, accordingly it may have different SPAS in the corresponding ASPAs.
+        Therefore, the above procedure with the input (AS1, AS2, AFI) may have different outputs for different AFI values.
       </t>
     </section>
 
-    <section title="AS_PATH Verification">
+    <section title="AS_PATH Verification" anchor="verif">
+<section title="Definition of Indices" anchor="index">
+
       <t>
         The AS_PATH attribute identifies the autonomous systems through which an UPDATE message has passed.
-        AS_PATH may contain two types of components: AS_SEQUENCEs and AS_SETs, as defined in <xref target="RFC4271" />.
+        It may contain two types of components: AS_SEQUENCEs and AS_SETs, as defined in <xref target="RFC4271" />. (Note: The consideration of AS Confederations is discussed in <xref target="confed"/>.)  
       </t>
       <t>
-        We will use index of AS_PATH, where Seg(1) stands for the first rightmost AS in the AS_PATH.
-        We will use Seg(I).value and Seg(I).type to represent Ith segment value and its type respectively.
+If the AS_PATH contains an AS_SET in any position, then it is marked by the verification algorithm as Invalid. (Note: AS_SETs are expected to be deprecated soon <xref target="RFC6472"/> <xref target="I-D.ietf-idr-deprecate-as-set-confed-set"/>.) If the AS_PATH does not contain an AS_SET but only AS_SEQUENCE(s), then it is represented for simplicity in the verification algorithm as a sequence of unique AS numbers: AS(1), AS(2),..., AS(I-1), AS(I), AS(I+1),..., AS(N), where AS(1) is the rightmost (i.e., origin) AS and AS(N) is the leftmost, i.e., the neighbor of the validating AS. N is the AS_PATH length in terms of the number of unique ASNs. (Note: see <xref target="non-transp-RS"/> for the consideration of a special case.) 
       </t>
       <t>
-        We define Invalid Pair Index as a minimal I such that Seg(I).type and Seg(I+1).type equal to AS_SEQUENCE, Seg(I).value != Seg(I+1).value and customer-provider validation procedure (<xref target="pair-validation"/>) with parameters (Seg(I).value, Seg(I+1).value, AFI) returns Invalid.
-        If I index doesn't exist we put the length of AS_PATH in its value.
+        An Invalid Pair Index is determined as a minimal I such that the customer-provider validation procedure (<xref target="pair-validation"/>) with parameters (AS(I), AS(I+1), AFI) returns Invalid.
+        If there is no such minimal I, then the Invalid Pair Index value is set equal to N.
       </t>
       <t>
-        We define Reverse Invalid Pair Index as Invalid Pair Index calculated for a reversed AS_PATH.
+        The Reverse Invalid Pair Index is determined as the Invalid Pair Index calculated for the reversed version of the sequence AS(1), AS(2),..., AS(I-1), AS(I), AS(I+1),..., AS(N).
       </t>
       <t>
-        We define Unknown Pair Index as a minimal I Seg(I).type and Seg(I+1).type equal to AS_SEQUENCE, Seg(I).value != Seg(I+1).value and customer-provider validation procedure (<xref target="pair-validation"/>) with parameters (Seg(I).value, Seg(I+1).value, AFI) returns Unknown.
-        If I is greater than Invalid Pair Index or I doesn't exist we equate its value to the value of Invalid Pair Index.
+        An Unknown Pair Index is determined as a minimal I such that the customer-provider validation procedure (<xref target="pair-validation"/>) with parameters (AS(I), AS(I+1), AFI) returns Unknown.
+        If there is no such minimal I or the minimal I value is greater than the Invalid Pair Index, then the Unknown Pair Index value is set equal to the Invalid Pair Index.
       </t>
       <t>
-        We define Reverse Unknown Pair Index as Unknown Pair Index calculated for a reversed AS_PATH.
+        The Reverse Unknown Pair Index is determined as the Unknown Pair Index calculated for the reversed version of the sequence AS(1), AS(2),..., AS(I-1), AS(I), AS(I+1),..., AS(N).
       </t>
       <t>
-        The below procedures are applicable only for 32-bit AS number compatible BGP speakers.
+        The procedures described in <xref target="Upflow"/> and <xref target="Downflow"/> make use of the four Indices defined above. Also, those procedures are applicable only to 32-bit AS number compatible BGP speakers.
       </t>
+      <section title="RS-Client of a Non-Transparent AS" anchor="non-transp-RS">
+        <t>
 
-      <section title="Upstream Paths" anchor="Upflow">
+A special consideration is given to the case when the validating AS is an RS-client of a non-transparent Route Server (RS). In this case, when the indices described <xref target="index"/> are computed, the ASN of the RS is removed from the AS_PATH only for the purpose generating the sequence AS(1), AS(2),... , AS(I-1), AS(I), AS(I+1),..., AS(N) that was defined in <xref target="index"/>. Thus, AS(N) would equal the AS number of the AS added just before the RS. Also, N would be one less than the AS_PATH length. 
+</t>
+<t>
+Note that when an UPDATE is received from an IX RS, it is equivalent to coming from a lateral peer regardless of whether the RS is transparent or not. Hence, the Upstream path validation procedure (<xref target="Upflow"/>) can be applied at the receiving RS-client in both cases (i.e., transparent and non-transparent) provided the non-transparent RS AS is removed as described above (preceding paragraph).
+ 
+
+<!-- A special consideration is given to the case of an RS-client of a transparent Route Server (RS) as follows. In this case, when the indices described <xref target="index"/> are computed, the ASN of the RS is added to the AS_PATH in the leftmost position (see design discussion in <xref target="sriram2"/>). Thus, in the sequence AS(1), AS(2),... , AS(I-1), AS(I), AS(I+1),..., AS(N) that was defined in <xref target="index"/>, AS(N) would equal the ASN of the RS. -->
+      
+        </t>
+      </section>
+      </section>
+
+      <section title="Algorithm for Upstream Paths" anchor="Upflow">
         <t>
-          When a route is received from a customer, a lateral peer, by a RS or RS-client at an IX, each consecutive AS_SEQUENCE pair MUST be equal (prepend policy) or belong to customer-provider or mutual transit relationship (<xref target="Complex"/>).
-          If there are other types of relationships, it means that the route was leaked or the AS_PATH attribute was malformed and Invalid Pair Index will be less than AS_PATH length.
+          The upstream verification algorithm described here is applied when a route is received from a customer or a lateral peer, or by an RS-client at an IX RS. Each hop AS(I) to AS(I+1)in the unique ASN sequence AS(1), AS(2),... , AS(N) must be Valid per the customer-provider validation procedure (<xref target="pair-validation"/>) for the AS_PATH to be Valid. If at least one of those hops is Invalid, then the AS_PATH would be Invalid. If the AS_PATH verification outcome is neither Valid nor Invalid, then it would be evaluated as Unknown.
         </t>
         <t>
-          If an attacker creates route leak intentionally he may try to strip his AS from the AS_PATH.
-          To strengthen route leak detection in case of malicious activity we need to check that AS_PATH is not empty and the latest AS in the AS_PATH equals to BGP neighbour AS with the exception for routes received from transparent IXes.
+          If an attacker creates a route leak intentionally, they may try to strip their AS from the AS_PATH. To partly guard against that, a check is performed to match the most recently added AS in the AS_PATH to the BGP neighbor's ASN. To further strengthen route leak detection against malicious activity, a check is performed to make sure that the AS_PATH is not empty. 
         </t>
+<!--
         <t>
-          At the of high adoption level there might be interest to distinguish between AS_PATHs that are Valid from AS_PATHs that can't be fully verified and may be leaked.
+          At a high adoption level there might be interest to distinguish between AS_PATHs that are Valid from AS_PATHs that cannot be fully verified and may be leaked.
           If route is received from a customer, a lateral peer, by a RS or RS-client at an IX and Unknown Pair Index is not equal to AS_PATH length it means that there is at least one AS without ASPA record.
         </t>
+-->
         <t>
-          The goal of the procedure described below is to check the correctness of these statements.
+          The upstream path verification procedure is specified as follows:
         </t>
         <t>
           <list style="numbers">
             <t>
-              If the AS_PATH has zero length then procedure halts with the outcome "Invalid";
+              If the AS_PATH has an AS_SET or zero length, then the procedure halts with the outcome "Invalid".
             </t>
             <t>
-              If the last segment in the AS_PATH has type AS_SEQUENCE and its value isn't equal to receiver's neighbor AS and receiver is not RS-client then procedure halts with the outcome "Invalid";
+              If the most recently added AS in the AS_PATH has a value not equal to the receiver's neighbor ASN, then the procedure halts with the outcome "Invalid".
             </t>
             <t>
-              If Invalid Pair Index is less than AS_PATH length then procedure halts with the outcome "Invalid";
+              If the Invalid Pair Index is less than N, then the procedure halts with the outcome "Invalid".
+            </t>
+            
+            <t>
+              If the Unknown Pair Index is less than N, then the procedure halts with the outcome "Unknown".
             </t>
             <t>
-              If the AS_PATH has at least one AS_SET segment then procedure halts with the outcome "Unverifiable";
-            </t>
-            <t>
-              If Unknown Pair Index is less than AS_PATH length then procedure halts with the outcome "Unknown";
-            </t>
-            <t>
-              Otherwise, the procedure halts with an outcome of "Valid".
+              Else, the procedure halts with the outcome "Valid".
             </t>
           </list>
         </t>
       </section>
 
-      <section title="Downstream Paths" anchor="Downflow">
+      <section title="Algorithm for Downstream Paths" anchor="Downflow">
         <t>
-          When a route is received from provider it may have both Upstream and Downstream fragments, where a Downstream follows an Upstream fragment.
+          The downstream verification algorithm described here is applied when a route is received from a transit provider. 
+        </t>
+        <t>
+Consider an UPDATE with the AS sequence AS(1), AS(2),... , AS(N) as defined in <xref target="index"/>. When the UPDATE is received from a provider, it may have both an upstream ramp and a downstream ramp, where the downstream ramp follows the upstream ramp (both ramps are ASPA valid hop-by-hop). A ramp stops when an ASPA validation to check customer-to-provider relationship of the next hop is unsuccessful (i.e., verification of the pair of ASes gives Invalid or Unknown result).  If there is an upstream ramp but no downstream ramp or vice versa, then clearly the UPDATE is valid (i.e., not a route leak). However, if both ramps exist, then the UPDATE is Valid if and only if either one or no AS hops exist between the apexes of the two ramps, i.e., there is no AS between the apexes (see <xref target="sriram1"/> for formal proof). If there are one or more ASes between the upstream and downstream ramps, then the UPDATE is a route leak (Invalid) or the presence of a leak cannot be known using available ASPAs (Unknown) <xref target="sriram1"/>.  
+</t>
+<t>
+The determination of a route leak (Invalid) UPDATE can be done with the use of the Invalid Pair Index and Reverse Invalid Pair Index.  The rule for Invalid determination is as follows: if the sum of Invalid Pair Index and Reverse Invalid Pair Index is less than N, then route was leaked or the AS_PATH attribute was malformed.
+
+<!--
+OLD TEXT
+          When a route is received from a transit provider it may have both Upstream and Downstream fragments, where a Downstream follows an Upstream fragment.
           If the path differs from this rule it means that the route was leaked or the AS_PATH attribute was malformed.
           This statement can be transformed into the next one: if there is at least one AS between the first Upstream fragment and the last Downstream fragment it is a route leak.
           The length of the first Upstream segment and last Downstream segment are defined by Invalid Pair Index and Reverse Invalid Pair Index respectively.
-          Using these indexes we can define next rule for route leak detection for routes received from providers: if sum of Invalid Pair Index and Reverse Invalid Pair Index is less than AS_PATH length, than route was leaked or the AS_PATH attribute was malformed.
+          Using these indexes we can define next rule for route leak detection for routes received from providers: if sum of Invalid Pair Index and Reverse Invalid Pair Index is less than AS_PATH length, then the route was leaked or the AS_PATH attribute was malformed.
+-->
+
         </t>
         <t>
-          Likewise we did in case of Upstream Paths, we need to check that AS_PATH is not empty and the latest AS in the AS_PATH equals to BGP neighbour AS.
+          As was done in the case of upstream paths <xref target="Upflow"/>, the checks regarding empty AS_PATH and match between the most recently added AS and the BGP neighbor AS are performed here also.
         </t>
+<!--
         <t>
-          Similar to route leak detection, we can distinguish the Valid AS_PATH from Unknown one by checking that sum of Unknown Pair Index and Reverse Unknown Pair Index is equal or greater than AS_PATH length.
+          Similar to route leak detection, we can distinguish the Valid AS_PATH from Unknown one by checking that sum of Unknown Pair Index and Reverse Unknown Pair Index is equal or greater than N.
         </t>
+-->
         <t>
-          The goal of the procedure described below is to check the correctness of these statements.
+          The downstream path verification procedure is specified as follows:
           <list style="numbers">
             <t>
-              If the AS_PATH has zero length then procedure halts with the outcome "Invalid";
+              If the AS_PATH has an AS_SET or zero length, then the procedure halts with the outcome "Invalid".
             </t>
             <t>
-              If a route is received from a provider and the last segment in the AS_PATH has type AS_SEQUENCE and its value isn't equal to receiver's neighbor AS, then the procedure halts with the outcome "Invalid";
+              If the most recently added AS in the AS_PATH has a value not equal to the receiver's neighbor ASN, then the procedure halts with the outcome "Invalid".
             </t>
             <t>
-              If sum of Invalid Pair Index and Reverse Invalid Pair Index is less than AS_PATH length, then the procedure halts with the outcome "Invalid".
-            </t>
-						<t>
-							If the AS_PATH has at least one AS_SET segment then procedure halts with the outcome "Unverifiable";
-						</t>
-            <t>
-              If sum of Unknown Pair Index and Unknown Invalid Pair Index is less than AS_PATH length, then the procedure halts with the outcome "Unknown".
+              If the sum of the Invalid Pair Index and the Reverse Invalid Pair Index is less than N, then the procedure halts with the outcome "Invalid".
             </t>
             <t>
-              Otherwise, the procedure halts with an outcome of "Valid".
+              If the sum of the Unknown Pair Index and the Reverse Unknown Pair Index is less than N, then the procedure halts with the outcome "Unknown".
+            </t>
+
+            <t>
+              Else, the procedure halts with the outcome "Valid".
             </t>
           </list>
         </t>
+      </section>
+      <section title="ASPA Registration Recommendations" anchor="rec1">
+      <t>
+        An ASPA is a positive attestation that an AS holder has authorized its providers to redistribute received routes to the provider's providers and lateral peers.
+        This does not preclude the provider AS from redistribution to its other customers. A customer AS MUST register each of its transit provider ASes in its ASPA(s). Preferably a customer AS SHOULD have a single ASPA object at any time. 
+<!--
+KS comment: The statement below does not make sense. The lateral peer of the customer is a provider to its customers and they can announce the routes further to the customers.
+
+        By creating an ASPA with providers set of [0], the customer indicates that no provider should further announce its routes.
+-->
+      </t>
+      <t>
+        Registration of an ASPA (AS, AFI, [0]) and no other ASPAs is meant to be a statement by the registering AS that it has no transit providers. An RS AS MUST register an AS 0 ASPA and MUST NOT register any other ASPAs. Normally, Tier-1 ASes do not have transit providers. However, if a Tier-1 AS is present at an IX RS as an RS-client, then it MUST register an ASPA showing the RS AS as a provider. 
+      </t>
+
+      <t>
+        An ASPA (AS, AFI, [0]) SHOULD be the only ASPA registered by an AS that wishes declare that it is provider-free in the selected AFI. If AS 0 coexists with other provider ASes in the same ASPA (or other ASPA records in the same AFI), then the presence of the AS 0 has no effect on the AS_PATH verification procedures. The validation procedures simply consider the other (distinct from AS 0) providers as the authorized providers of the AS in consideration.    
+      </t>
+
+      </section>
+      <section title="AS Path Verification Recommendation" anchor="rec2">
+
+        <t>
+A compliant AS MUST apply the upstream and downstream AS path validation algorithms (<xref target="Upflow"/> and <xref target="Downflow"/>, respectively) in principle producing outcomes as specified though the implementation details may differ.    
+        </t>
+      </section>
       </section>
 
       <section title="Mitigation">
         <t>
-          If the output of the AS_PATH verification procedure is "Invalid" the route MUST be rejected.
+          If the output of the AS_PATH verification procedure is "Invalid", then the route MUST be rejected.
         </t>
+<!--
         <t>
-          If the output of the AS_PATH verification procedure is 'Unverifiable' it means that AS_PATH can't be fully checked.
+          If the output of the AS_PATH verification procedure is 'Unverifiable' it means that AS_PATH cannot be fully checked.
             Such routes should be treated with caution and SHOULD be processed the same way as "Invalid" routes.
-            This policy goes with full correspondence to <xref target="I-D.kumari-deprecate-as-set-confed-set"/>.
+            This policy goes with full correspondence to <xref target="I-D.ietf-idr-deprecate-as-set-confed-set"/>.
         </t>
+-->
         <t>
-          The above AS_PATH verification procedure is able to check routes received from customer, peers, providers, RS, and RS-clients.
-          The ASPA mechanism combined with BGP Roles <xref target="RFC9234" /> and ROA-based Origin Validation <xref target="RFC6483" /> can provide a fully automated solution to detect and filter hijacks and route leaks, including malicious ones.
+          The above AS_PATH verification procedures (<xref target="Upflow"/> and <xref target="Downflow"/>) are able to check routes received from customers, lateral peers, transit providers, RSes, and RS-clients.
+          The ASPA-based path verification mechanism combined with BGP Roles <xref target="RFC9234" /> and ROA-based Origin Validation <xref target="RFC6811" /> can provide a fully automated solution to detect and filter hijacks and route leaks, including malicious ones (e.g., forged-origin hijacks).
         </t>
     </section>
-    </section>
 
-    <section title="Disavowal of Provider Authorizaion">
-      <t>
-        An ASPA is a positive attestation that an AS holder has authorized its providers to redistribute received routes to the provider's providers and peers.
-        This does not preclude the provider ASes from redistribution to its other customers.
-        By creating an ASPA with providers set of [0], the customer indicates that no provider should further announce its routes.
-        Specifically, AS 0 is reserved to identify provider-free networks, Internet exchange meshes, etc.
-      </t>
-
-      <t>
-        An ASPA(AS, AFI, [0]) is a statement by the customer AS that its routes should not be received by any relying party AS from any of its customers or peers.
-      </t>
-
-      <t>
-        By convention, an ASPA(AS, AFI, [0]) should be the only ASPA issued by a given AS holder in the selected AFI; although this is not a strict requirement.
-        An AS 0 may coexist with other provider ASes in the same ASPA (or other ASPA records in the same AFI); though in such cases, the presence or absence of the provider AS 0 in ASPA does not alter the AS_PATH verification procedure.
-      </t>
-    </section>
+    <section title="Operational Considerations">
 
     <section title="Mutual Transit (Complex Relations)" anchor="Complex">
       <t>
-        There are peering relationships which can not be described as strictly simple peer-peer or customer-provider; e.g. when both parties are intentionally sending prefixes received from each other to their peers and/or upstreams.
-      </t>
-
-      <t>
-        In this case, two corresponding records ASPA(AS1, AFI, [AS2, ...]), ASPA(AS2, AFI, [AS1, ...]) must be created by AS1 and AS2 respectively.
+        There are peering relationships which cannot be described as strictly simple peer-to-peer (i.e., lateral peers) or customer-to-provider. An example is when both parties (ASes) treat each other as a customer, i.e., the customer-to-provider relationship applies in each direction. That is called a sibling relationship, and in such case, an ASPA (AS1, AFI, [AS2, ...]) must be created by AS1 and another ASPA (AS2, AFI, [AS1, ...]) must be created by AS2.
       </t>
     </section>
 
+    <section title="AS Confederations" anchor="confed">
+      <t>
+The ASes on the boundary of an AS Confederation MUST register ASPAs using the Confederation's global ASN and the procedures for ASPA-based AS path validation in this document are NOT RECOMMENDED for use on eBGP links internal to the Confederation.
+      </t>
+    </section>
+    </section>
+
+
+
     <section title="Comparison to Peerlock">
       <t>
-        ASPA has much in common with <xref target="Peerlock"/>.
-        Peerlock is a <xref target="Flexsealing">BGP Flexsealing</xref> protection mechanism commonly deployed by global-scale Internet carriers to protect other large-scale carriers.
+        The Peerlock mechanism <xref target="Peerlock"/> <xref target="Flexsealing"/> has a similar objective as the APSA-based route leak protection mechanism described in this document.
+        It is commonly deployed by large Internet carriers to protect each other from route leaks.
+        Peerlock depends on a laborious manual process in which operators coordinate the distribution of unstructured Provider Authorizations through out-of-band means in a many-to-many fashion.
+        On the other hand, ASPA's use of <xref target="RFC5280">PKIX</xref> allows for automated, scalable, and ubiquitous deployment, making the protection mechanism available to a wider range of network operators.
       </t>
       <t>
-        Peerlock, unfortunately, depends on a laborious manual process in which operators coordinate the distribution of unstructured Provider Authorizations through out-of-band means in a many-to-many fashion.
-        On the other hand, ASPA's use of <xref target="RFC5280">PKIX</xref> allows for automated, scalable, and ubiquitous deployment, making the protection mechanism available to a wider range of Internet Number Resource holders.
-      </t>
-      <t>
-        ASPA mechanics implemented in code instead of Peerlock AS_PATH regular expressions also provides a way to detect anomalies coming from transit providers and internet exchange route servers.
-      </t>
-      <t>
+        The ASPA mechanism implemented in router code versus Peerlock's AS_PATH regular expressions also provides a way to detect anomalies propagated from transit providers and IX route servers.
         ASPA is intended to be a complete solution and replacement for existing Peerlock deployments.
       </t>
     </section>
 
+    <section anchor="IANA" title="IANA Considerations">
+      <t> This document includes no request to IANA. </t>
+    </section>
+
+
     <section anchor="Security" title="Security Considerations">
       <t>
         The proposed mechanism is compatible only with BGP implementations that can process 32-bit ASNs in the AS_PATH.
-        This limitation should not have a real effect on operations - such legacy BGP routers are rare and it's highly unlikely that they support integration with the RPKI.
+        This limitation should not have a real effect on operations since legacy BGP routers are rare and it is highly unlikely that they support integration with the RPKI.
       </t>
 
       <t>
-        ASPA issuers should be aware of the validation implication in issuing an ASPA - an ASPA implicitly invalidates all routes passed to upstream providers other than the provider ASs listed in the ASPA record.
-        It is the Customer AS's duty to maintain a correct set of providers in ASPA record(s).
+        ASPA issuers should be aware of the implications of the ASPA-based AS path verification. A downstream AS can apply the verification mechanism and possibly invalidate and reject all routes passed to upstream providers other than the provider ASes listed in the ASPA record.
+        It is the responsibility of each compliant AS to maintain a correct set of providers in its ASPA record(s).
       </t>
 
       <t>
-        While it's not restricted, but it's highly recommended maintaining for selected Customer AS a single ASPA object that covers all its providers.
-        Such policy should prevent race conditions during ASPA updates that might affect prefix propagation.
-        The software that provides hosting for ASPA records SHOULD support enforcement of this rule.
-        In the case of the transition process between different CA registries, the ASPA records SHOULD be kept identical in all registries.
+        It is highly recommended that a compliant AS should maintain a single ASPA object that covers all its providers.
+        Such a practice will help prevent race conditions during ASPA updates that might affect prefix propagation.
+        The software that provides hosting for ASPA records SHOULD support enforcement of this practice.
+        During a transition process between different certificate authority (CA) registries, the ASPA records SHOULD be kept identical in all registries.
       </t>
 
       <t>
-        While the ASPA is able to detect both mistakes and malicious activity for routes received from customers, RS-clients, or peers, it provides only detection of mistakes for routes that are received from upstream providers and RS(s).
+        While the ASPA-based mechanism is able to generally detect both mistakes and malicious activity affecting routes received from customers, RS-clients, or lateral peers, it might fail to detect some malicious path modifications for routes that are received from upstream providers.
       </t>
 
       <t>
-				Since an upstream provider becomes a trusted point, it will be able to send hijacked prefixes of its customers or send hijacked prefixes with malformed AS_PATHs back.
-        While it may happen in theory, it's doesn't seem to be a real scenario: normally customer and provider have a signed agreement and such policy violation should have legal consequences or customer can just drop relation with such a provider and remove the corresponding ASPA record.
+				Since an upstream provider becomes a trusted point, in theory it might be able to propagate without detection some instances of hijacked prefixes of its customers or routes with malformed AS_PATHs.
+        While it may happen in theory, it does not seem to be a realistic scenario. Normally a customer and its transit provider have a signed agreement and such a policy violation should have legal consequences or customer can just drop the relationship with such a provider and remove the corresponding ASPA record.
       </t>
     </section>
 
     <section anchor="Acknowledgments" title="Acknowledgments">
       <t>
-        The authors wish to thank authors of <xref target="RFC6483" /> since its text was used as an example while writing this document.
-				The authors wish to thank Iljitsch van Beijnum for giving a hint about Downstream paths.
-        Authors wish to thank Kotikalapudi Sriram for algorithm improvements and helping with text clarity in the document.
+        The authors wish to thank the authors of <xref target="RFC6483" /> since its text was used as an example while writing <xref target="ASPA"/> in this document. Thanks are also due to Jakob Heitz, Ben Maddison, Jeff Haas, and Nick Hilliard  for comments and discussion about the algorithms. The authors wish to thank Iljitsch van Beijnum for providing a suggestion about downstream paths.
       </t>
     </section>
 
@@ -397,22 +453,24 @@
   <back>
     <references title="Normative References">
       &RFC2119;
+      &RFC6811;
+      &RFC6480;
+      &RFC5280;
+      &RFC4271;
+      &RFC7908;
       &RFC8174;
     </references>
 
     <references title="Informative References">
-      &RFC7908;
+      &RFC3779;
+      &RFC6472;
       &RFC8205;
       &RFC6483;
-      &RFC6480;
-      &RFC5280;
-      &RFC4271;
-      &RFC3779;
       &RFC9234;
       &I-D.ietf-grow-route-leak-detection-mitigation;
       &I-D.white-sobgp-architecture;
       &I-D.ietf-sidrops-aspa-profile;
-      &I-D.draft-kumari-deprecate-as-set-confed-set;
+      &I-D.ietf-idr-deprecate-as-set-confed-set;
       <reference anchor="Peerlock" target="https://www.nanog.org/sites/default/files/Snijders_Everyday_Practical_Bgp.pdf">
         <front>
           <title>Peerlock</title>
@@ -437,6 +495,26 @@
           <date month="November" year="2020"/>
         </front>
       </reference>
+        <reference anchor="sriram1" target="https://datatracker.ietf.org/meeting/110/materials/slides-110-sidrops-sriram-aspa-alg-accuracy-01">       
+            <front>
+                <title>On the Accuracy of Algorithms for ASPA Based Route Leak Detection</title>
+                <author initials="K." surname="Sriram"><organization /></author>
+                <author initials="J." surname="Heitz"><organization /></author>
+                <date year="" />
+            </front>
+            <seriesInfo name="IETF SIDROPS Meeting," value="Proceedings of the IETF 110, March 2021" />
+        </reference>
+<!--
+        <reference anchor="sriram2" target="https://datatracker.ietf.org/meeting/113/materials/slides-113-sidrops-aspa-verification-procedures-01">       
+            <front>
+                <title>ASPA Verification Procedures: Enhancements and RS Considerations</title>
+                <author initials="K." surname="Sriram"><organization /></author>
+                <date year="" />
+            </front>
+            <seriesInfo name="IETF SIDROPS Meeting," value="Proceedings of the IETF 113, March 2022" />
+        </reference>
+-->
     </references>
   </back>
 </rfc>
+

--- a/draft-azimov-sidrops-aspa-verification.xml
+++ b/draft-azimov-sidrops-aspa-verification.xml
@@ -77,7 +77,7 @@
           <street />
           <code />
           <city>Amsterdam</city>
-          <country>The Netherlands</country>
+          <country>NL</country>
         </postal>
         <email>job@fastly.com</email>
       </address>


### PR DESCRIPTION
I put in quite substantial effort into it. Hopefully, nearly ready for a WGLC. The changes include the following:

1.      Wrote up algorithm descriptions avoiding the use of Segment(i) notation. We now use simply the AS sequence of AS(1), AS(2), … of unique ASNs since AS_SETs do not occur in the middle.

2.      AS_SET is taken care of in the algorithm in accordance with the WG consensus. Presence of AS_SET anywhere now makes the AS_PATH Invalid.

3.      Customary section on AS Confederations included (paragraph/wording has support from Jeff Haas; see WG list discussion).

4.      RS (transparent/non-transparent) appropriately taken care of in the algorithms. Upstream algorithm is applied in both cases. RS AS in removed from AS path in the case of non-transparent RS. This makes the validation outcomes in the transparent and non-transparent cases consistent (identical for any given scenario).

5.      Created new sections:  5.4.  ASPA Registration Recommendations;  5.5.  AS Path Verification Recommendation;  7.  Operational Considerations;   and  9.  IANA Considerations.

6.      Did some sanity checks and included changes normally asked during AD/IESG review cycle.

7.      Sorted out the references more accurately into normative and informational.

8.      Went through the whole document and made changes to improve clarity and readability, and cleaned up English language issues.